### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps  {org.clojure/tools.reader    {:mvn/version "1.3.0"}
-         fipp                        {:mvn/version "0.6.14"}
+         fipp/fipp                   {:mvn/version "0.6.14"}
          mvxcvi/puget                {:mvn/version "1.1.2"}
          jline/jline                 {:mvn/version "2.14.2"}}
  :aliases {:test {:extra-paths ["test"] 


### PR DESCRIPTION
We are in the process of deprecating the unqualified lib symbol syntax.